### PR TITLE
Use external prop-types package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,8 @@ var taskConfig = {
 		dependencies: [
 			'classnames',
 			'react',
-			'react-dom'
+			'react-dom',
+			'prop-types'
 		],
 		lib: 'lib'
 	},

--- a/lib/ReactInputValidation.js
+++ b/lib/ReactInputValidation.js
@@ -16,7 +16,11 @@ function _inherits(subClass, superClass) { if (typeof superClass !== 'function' 
 
 var _react = require('react');
 
+var PropTypes = require('prop-types');
+
 var _react2 = _interopRequireDefault(_react);
+
+_react2['default'].PropTypes = PropTypes;
 
 var _libValidationRules = require('./lib/validation-rules');
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/ggayane/react-input-validation/issues"
   },
   "dependencies": {
-    "classnames": "^2.1.2"
+    "classnames": "^2.1.2",
+    "prop-types"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "classnames": "^2.1.2",
-    "prop-types"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",


### PR DESCRIPTION
In some versions of react, React.PropTypes is no longer available. This revision imports the prop-types package and makes its main object available to the library through React.PropTypes, thus not having to change any other code.